### PR TITLE
Use api instead of implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,12 +101,10 @@ android {
 }
 
 dependencies {
-    implementation 'com.amazonaws:aws-android-sdk-core:2.6.22'
-    implementation 'com.amazonaws:aws-android-sdk-s3:2.6.22'
-    testImplementation 'commons-logging:commons-logging:1.1.1'
-
+    api 'com.amazonaws:aws-android-sdk-core:2.6.22'
+    api 'com.amazonaws:aws-android-sdk-s3:2.6.22'
     implementation 'com.snatik:storage:2.1.0'
-
+    testImplementation 'commons-logging:commons-logging:1.1.1'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.powermock:powermock-api-mockito:1.6.6'
     testImplementation 'org.powermock:powermock-module-junit4:1.6.6'


### PR DESCRIPTION
After updating my version of gradle in my main project (for example TimeClock), some of the dependencies I needed were missing.  In this case, certain Amazon classes I use when uploading amazon logs were now missing.

The problem is that the later versions of Gradle will ignore transitive dependencies with `runtime` scope.  Dependencies with `runtime` scope are meant to only be used by the library and not to be imported into the main project.  The resolution is to make sure that the transitive dependencies are scoped correctly.

[Here is an example of what the .pom file used to look like](https://jitpack.io/com/github/stephenruda/simple-logger-android/pom-test-637a9a8ccd-1/simple-logger-android-pom-test-637a9a8ccd-1.pom).  Notice the `runtime` scope for the amazon sdk dependencies.
[Here is an example of what the .pom file needs to look like](https://jitpack.io/com/github/stephenruda/simple-logger-android/try3-3d4fb5b3fc-1/simple-logger-android-try3-3d4fb5b3fc-1.pom).  Notice the scope for this is `compile` so those libraries will be imported.

[The solution is very simple](https://stackoverflow.com/a/54931133/6754511).  Just specifying `api` instead of `implementation` when I import the library so that the pom file gets generated correctly.  Really this is the way it should've always been but I just didn't realize it because my older version of gradle had no problems pulling in those runtime dependencies.  Now that I have updated gradle I need to update this library.